### PR TITLE
Finalized workflow split in law

### DIFF
--- a/scripts/DevBatch.sh
+++ b/scripts/DevBatch.sh
@@ -19,13 +19,13 @@ FILE1="/data/dust/user/bliewert/zhh/FastSimSGV/550-llhh-fast-perf/E550-Test.Pe2e
 NAME1="llhh"
 NEVT1=100
 
-#FILE2="/data/dust/user/bliewert/zhh/FastSimSGV/550-llbb-fast-perf/E550_TDR.Pllbb_sl0.Gwhizard-3.1.4.eL.pR.slcio"
-#NAME2="llbb"
-#NEVT2=500
-
-FILE2="/data/dust/user/bliewert/zhh/FastSimSGV/550-llhh-fast-perf/E550-Test.Pe2e2qqh.Gwhizard-2_8_5.eL.pR.I404011.0.slcio"
-NAME2="llqqh"
+FILE2="/data/dust/user/bliewert/zhh/FastSimSGV/550-llbb-fast-perf/E550_TDR.Pllbb_sl0.Gwhizard-3.1.4.eL.pR.slcio"
+NAME2="llbb"
 NEVT2=100
+
+#FILE2="/data/dust/user/bliewert/zhh/FastSimSGV/550-llhh-fast-perf/E550-Test.Pe2e2qqh.Gwhizard-2_8_5.eL.pR.I404011.0.slcio"
+#NAME2="llqqh"
+#NEVT2=100
 
 # how many jobs are spawned PER INPUT FILE
 USE_CLUSTER_N_JOBS=20

--- a/scripts/dev_flavortag_compare.xml
+++ b/scripts/dev_flavortag_compare.xml
@@ -17,8 +17,8 @@
         <constant name="RunTruthRecoComparison" value="False" />
 
         <!-- These variables should be constant -->
-        <constant name="LCFIPlusML_ONNX" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgvnew_3cat_cut/ilc_nnqq_sgvnew_3cat_cut.onnx" />
-        <constant name="LCFIPlusML_JSON" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgvnew_3cat_cut/preprocess.json" />
+        <constant name="LCFIPlusML_ONNX" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgv1m_11cat/ilc_nnqq_sgv1m_11cat.onnx" />
+        <constant name="LCFIPlusML_JSON" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgv1m_11cat/preprocess.json" />
 
         <constant name="lcgeo_DIR" value="/cvmfs/sw.hsf.org/key4hep/releases/2024-03-10/x86_64-centos7-gcc12.2.0-opt/k4geo/0.20-e42drs/share/k4geo" />
         <constant name="DetectorModel" value="ILD_l5_o1_v02" />

--- a/scripts/prod.xml
+++ b/scripts/prod.xml
@@ -25,8 +25,8 @@
         <constant name="errorflowconfusion" value="true" />
 
         <!-- These variables should be constant -->
-        <constant name="LCFIPlusML_ONNX" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgvnew_3cat_cut/ilc_nnqq_sgvnew_3cat_cut.onnx" />
-        <constant name="LCFIPlusML_JSON" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgvnew_3cat_cut/preprocess.json" />
+        <constant name="LCFIPlusML_ONNX" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgv1m_11cat/ilc_nnqq_sgv1m_11cat.onnx" />
+        <constant name="LCFIPlusML_JSON" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgv1m_11cat/preprocess.json" />
 
         <constant name="lcgeo_DIR" value="/cvmfs/sw.hsf.org/key4hep/releases/2024-03-10/x86_64-centos7-gcc12.2.0-opt/k4geo/0.20-e42drs/share/k4geo" />
         <constant name="DetectorModel" value="ILD_l5_o1_v02" />

--- a/scripts/prod_analysis.xml
+++ b/scripts/prod_analysis.xml
@@ -39,6 +39,7 @@
         <parameter name="Verbosity" type="string">${Verbosity}</parameter>
     </processor>
 
+    <!--
     <processor name="MyTrueJet" type="TrueJet">
         <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">${MCParticleCollectionName}</parameter>
         <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle">PandoraPFOs</parameter>
@@ -54,6 +55,7 @@
         <parameter name="InitialColourNeutralLink" type="string" lcioOutType="LCRelation">InitialColourNeutralLink</parameter>
         <parameter name="Verbosity" type="string">${Verbosity}</parameter>
     </processor>
+    -->
 </group>
 
 <group name="prodAnalysisLL">
@@ -285,6 +287,7 @@
         <parameter name="JetCollectionName" type="string" lcioInType="ReconstructedParticle">RefinedJets4</parameter>
         <parameter name="2JetCollectionName" type="string" lcioInType="ReconstructedParticle">RefinedJets2</parameter>
         <parameter name="inputPfoCollection" type="string" lcioInType="ReconstructedParticle">${PFOsWithoutOverlayCollection}</parameter>
+        <parameter name="MCParticleCollection" type="string" lcioInType="MCParticle">${MCParticleCollectionName}</parameter>
 
         <parameter name="JetsKinFitZHH" type="string" lcioInType="ReconstructedParticle">JetsKinFit_ZHH</parameter>
         <parameter name="JetsKinFitZZH" type="string" lcioInType="ReconstructedParticle">JetsKinFit_ZZH</parameter>
@@ -292,6 +295,9 @@
         <parameter name="JetTaggingPIDAlgorithm" type="string">weaver</parameter>
         <parameter name="JetTaggingPIDParameterB" type="string">mc_b</parameter>
         <parameter name="JetTaggingPIDParameterC" type="string">mc_c</parameter>
+        <parameter name="JetTaggingPIDParameterBbar" type="string">mc_bbar</parameter>
+        <parameter name="JetTaggingPIDParameterCbar" type="string">mc_cbar</parameter>
+        <parameter name="JetTaggingPIDParameters" type="StringVec">mc_b mc_bbar mc_c mc_cbar mc_d mc_dbar mc_g mc_s mc_sbar mc_u mc_ubar</parameter>
 
         <parameter name="JetTaggingPIDAlgorithm2" type="string">lcfiplus</parameter>
         <parameter name="JetTaggingPIDParameterB2" type="string">BTag</parameter>
@@ -301,7 +307,7 @@
 
         <parameter name="ECM" type="float"> ${CMSEnergy} </parameter>
 
-        <parameter name="Verbosity" type="string">DEBUG</parameter>
+        <parameter name="Verbosity" type="string">${Verbosity}</parameter>
     </processor>
 
     <!--

--- a/scripts/prod_reco_run.xml
+++ b/scripts/prod_reco_run.xml
@@ -25,8 +25,8 @@
         <constant name="errorflowconfusion" value="true" />
 
         <!-- These variables should be constant -->
-        <constant name="LCFIPlusML_ONNX" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgvnew_3cat_cut/ilc_nnqq_sgvnew_3cat_cut.onnx" />
-        <constant name="LCFIPlusML_JSON" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgvnew_3cat_cut/preprocess.json" />
+        <constant name="LCFIPlusML_ONNX" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgv1m_11cat/ilc_nnqq_sgv1m_11cat.onnx" />
+        <constant name="LCFIPlusML_JSON" value="${ZHH_REPO_ROOT}/dependencies/LCFIPlusConfig/onnx/ilc_nnqq_sgv1m_11cat/preprocess.json" />
 
         <constant name="lcgeo_DIR" value="/cvmfs/sw.hsf.org/key4hep/releases/2024-03-10/x86_64-centos7-gcc12.2.0-opt/k4geo/0.20-e42drs/share/k4geo" />
         <constant name="DetectorModel" value="ILD_l5_o1_v02" />

--- a/scripts/run_preselection.py
+++ b/scripts/run_preselection.py
@@ -1,6 +1,6 @@
 import argparse
 from zhh import EventCategories, PreselectionProcessor, \
-    categorize_6q, categorize_2l4q, categorize_llbb, categorize_llhh
+    categorize_6q, categorize_2l4q, categorize_4fsl, categorize_llhh
 import numpy as np
 from tqdm.auto import tqdm
 from zhh import AnalysisChannel, EventCategories
@@ -8,20 +8,20 @@ from zhh import AnalysisChannel, EventCategories
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--llbb', type=str,
-                        default='/data/dust/user/bliewert/zhh/AnalysisCombine/550-llbb-fast-perf',
-                        help='Path to AnalaysisCombine output directory for llbb')
+    parser.add_argument('--f4sl', type=str,
+                        default='/data/dust/user/bliewert/zhh/AnalysisCombine.old/550-4fsl-fast-perf',
+                        help='Path to AnalaysisCombine output directory for 4fsl')
     
     parser.add_argument('--l2q4', type=str,
-                        default='/data/dust/user/bliewert/zhh/AnalysisCombine/550-2l4q-fast-perf.old',
+                        default='/data/dust/user/bliewert/zhh/AnalysisCombine.old/550-2l4q-fast-perf',
                         help='Path to AnalaysisCombine output directory of 2l4q')
 
     parser.add_argument('--llhh', type=str,
-                        default='/data/dust/user/bliewert/zhh/AnalysisCombine/550-llhh-fast-perf',
+                        default='/data/dust/user/bliewert/zhh/AnalysisCombine.old/550-llhh-fast-perf',
                         help='Path to AnalaysisCombine output directory of llhh')
     
     parser.add_argument('--q6', type=str,
-                        default='/data/dust/user/bliewert/zhh/AnalysisCombine/550-6q-fast-perf',
+                        default='/data/dust/user/bliewert/zhh/AnalysisCombine.old/550-6q-fast-perf',
                         help='Path to AnalaysisCombine output directory of 6q')
     
     parser.add_argument('--output', type=str,
@@ -32,12 +32,12 @@ if __name__ == "__main__":
 
     PRESELECTION = 'll'
 
-    llbb = AnalysisChannel(args.llbb, 'llbb')
+    f4sl = AnalysisChannel(args.f4sl, '4fsl')
     l2q4 = AnalysisChannel(args.l2q4, '2l4q')
     llhh = AnalysisChannel(args.llhh, 'llhh')
     q6 = AnalysisChannel(args.q6, '6q')
 
-    sources = [llbb, l2q4, llhh, q6]
+    sources = [f4sl, l2q4, llhh, q6]
 
     for source in tqdm(sources):
         source.combine()
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     # categorize each event based on output of FinalStateRecorder
     for analysis_channel, cat_fn, default_category, category_order in [
-        (llbb, categorize_llbb, EventCategories.llbb, None),
+        (f4sl, categorize_4fsl, EventCategories.F4_OTHER, None),
         (l2q4, categorize_2l4q, EventCategories.F6_OTHER, None),
         (llhh, categorize_llhh, None, None),
         (q6, categorize_6q, EventCategories.qqqqqq, [])

--- a/source/EventObservables/include/EventObservablesLL.h
+++ b/source/EventObservables/include/EventObservablesLL.h
@@ -44,6 +44,7 @@ class EventObservablesLL : public EventObservablesBase {
 		std::string m_inputIsoElectrons{};
 		std::string m_inputIsoMuons{};
 		std::string m_inputIsoTaus{};
+		std::vector<string> m_2JetTaggingPIDParameters{};
 
 		std::string m_JMP{};
 		std::string m_JMSP{};
@@ -53,16 +54,8 @@ class EventObservablesLL : public EventObservablesBase {
 		int m_npfosmax4j{};
 
 		// isolated lepton momenta and energies
-		float m_pxl1{};
-		float m_pyl1{};
-		float m_pzl1{};
-		float m_el1{};
+		std::vector<ROOT::Math::PxPyPzEVector> m_leps4v{};
 		int m_typel1{};
-
-		float m_pxl2{};
-		float m_pyl2{};
-		float m_pzl2{};
-		float m_el2{};
 		int m_typel2{};
 
 		float m_plmin{};
@@ -74,23 +67,17 @@ class EventObservablesLL : public EventObservablesBase {
 		float m_mzll_pre_pairing{};
 
 		// 2 jet
-		float m_pxj1_2Jets{};
-		float m_pyj1_2Jets{};
-		float m_pzj1_2Jets{};
-		float m_ej1_2Jets{};
-
-		float m_pxj2_2Jets{};
-		float m_pyj2_2Jets{};
-		float m_pzj2_2Jets{};
-		float m_ej2_2Jets{};
+		std::vector<std::vector<float>> m_2jetTags{};
+		std::vector<ROOT::Math::PxPyPzEVector> m_2jets4v{};
+		float m_2jet1_m{};
+		float m_2jet2_m{};
+		float m_2jet_m_inv{};
 
 		float m_ptjmin2{};
 		float m_pjmin2{};
 
 		float m_ptjmax2{};
 		float m_pjmax2{};
-
-		float m_m_inv_2Jets{};
 
 		float m_cosJ1_2Jets{};
 		float m_cosJ2_2Jets{};

--- a/source/EventObservables/src/EventObservablesLL.cc
+++ b/source/EventObservables/src/EventObservablesLL.cc
@@ -41,23 +41,21 @@ m_JMP("best_perm_ll") {
 void EventObservablesLL::prepareChannelTree() {
     TTree* ttree = getTTree();
 
+    m_2jetTags = std::vector<std::vector<float>>(2);
     m_bTagValues_2Jets  = std::vector<double>(2, -1.);
     m_bTagValues_2Jets2 = std::vector<double>(2, -1.);
+
+    m_leps4v = std::vector<ROOT::Math::PxPyPzEVector>(m_nAskedIsoLeps());
+    m_2jets4v = std::vector<ROOT::Math::PxPyPzEVector>(2);
 
 	if (m_write_ttree) {
         ttree->Branch("npfosmin4j", &m_npfosmin4j, "npfosmin4j/I");
 		ttree->Branch("npfosmax4j", &m_npfosmax4j, "npfosmax4j/I");
 
-        ttree->Branch("pxl1", &m_pxl1, "pxl1/F");
-		ttree->Branch("pyl1", &m_pyl1, "pyl1/F");
-		ttree->Branch("pzl1", &m_pzl1, "pzl1/F");
-		ttree->Branch("el1", &m_el1, "el1/F");
+        ttree->Branch("lep1_4v", &m_leps4v[0]);
         ttree->Branch("typel1", &m_typel1, "typel1/I");
 
-		ttree->Branch("pxl2", &m_pxl2, "pxl2/F");
-		ttree->Branch("pyl2", &m_pyl2, "pyl2/F");
-		ttree->Branch("pzl2", &m_pzl2, "pzl2/F");
-		ttree->Branch("el2", &m_el2, "el2/F");
+        ttree->Branch("lep2_4v", &m_leps4v[1]);
         ttree->Branch("typel2", &m_typel2, "typel2/I");
 
         ttree->Branch("plmin", &m_plmin, "plmin/F");
@@ -67,17 +65,14 @@ void EventObservablesLL::prepareChannelTree() {
         ttree->Branch("mzll", &m_mzll, "mzll/F");
         ttree->Branch("mzll_pre_pairing", &m_mzll_pre_pairing, "mzll_pre_pairing/F");
         
-
         // 2 jets
-        ttree->Branch("pxj1_2Jets", &m_pxj1_2Jets, "pxj1_2Jets/F");
-		ttree->Branch("pyj1_2Jets", &m_pyj1_2Jets, "pyj1_2Jets/F");
-		ttree->Branch("pzj1_2Jets", &m_pzj1_2Jets, "pzj1_2Jets/F");
-		ttree->Branch("ej1_2Jets", &m_ej1_2Jets, "ej1_2Jets/F");
+        ttree->Branch("2jets_m_inv", &m_2jet_m_inv, "2jets_m_inv/F");
+        
+        ttree->Branch("2jet1_4v", &m_jets4v[0]);
+		ttree->Branch("2jet1_m", &m_2jet1_m, "2jet1_m/F");
 
-		ttree->Branch("pxj2_2Jets", &m_pxj2_2Jets, "pxj2_2Jets/F");
-		ttree->Branch("pyj2_2Jets", &m_pyj2_2Jets, "pyj2_2Jets/F");
-		ttree->Branch("pzj2_2Jets", &m_pzj2_2Jets, "pzj2_2Jets/F");
-		ttree->Branch("ej2_2Jets", &m_ej2_2Jets, "ej2_2Jets/F");
+        ttree->Branch("2jet2_4v", &m_jets4v[0]);
+		ttree->Branch("2jet2_m", &m_2jet2_m, "2jet2_m/F");
 
         ttree->Branch("cosJ1_2Jets", &m_cosJ1_2Jets, "cosJ1_2Jets/F");
         ttree->Branch("cosJ2_2Jets", &m_cosJ2_2Jets, "cosJ2_2Jets/F");
@@ -92,14 +87,13 @@ void EventObservablesLL::prepareChannelTree() {
         ttree->Branch("ptjmax2", &m_ptjmax2, "ptjmax2/F");
         ttree->Branch("pjmax2", &m_pjmax2, "pjmax2/F");
 
-        ttree->Branch("m_inv_2Jets", &m_m_inv_2Jets, "m_inv_2Jets/F");
-
         ttree->Branch("yminus2", &m_yMinus2, "yminus2/F");
         ttree->Branch("yplus2", &m_yPlus2, "yplus2/F");
 
         ttree->Branch("bmax1_2Jets", &m_bmax1_2Jets, "bmax1_2Jets/F");
         ttree->Branch("bmax2_2Jets", &m_bmax2_2Jets, "bmax2_2Jets/F");
 
+        ttree->Branch("2jetTags", &m_2jetTags);
         ttree->Branch("bTagValues_2Jets", &m_bTagValues_2Jets);
 
         if (m_use_tags2) {
@@ -120,16 +114,10 @@ void EventObservablesLL::clearChannelValues() {
     m_npfosmin4j = 0;
     m_npfosmax4j = 0;
 
-    m_pxl1 = 0.;
-    m_pyl1 = 0.;
-    m_pzl1 = 0.;
-    m_el1 = 0.;
+    m_leps4v[0].SetPxPyPzE(0., 0., 0., 0.);
     m_typel1 = 0;
 
-    m_pxl2 = 0.;
-    m_pyl2 = 0.;
-    m_pzl2 = 0.;
-    m_el2 = 0.;
+    m_leps4v[1].SetPxPyPzE(0., 0., 0., 0.);
     m_typel2 = 0;
 
     m_plmin = 0;
@@ -140,15 +128,11 @@ void EventObservablesLL::clearChannelValues() {
 	m_mzll_pre_pairing = 0.;
 
     // 2 jets
-    m_pxj1_2Jets = 0.;
-	m_pyj1_2Jets = 0.;
-	m_pzj1_2Jets = 0.;
-	m_ej1_2Jets  = 0.;
+    m_2jets4v[0].SetPxPyPzE(0., 0., 0., 0.);
+    m_2jet1_m = 0.;
 
-    m_pxj2_2Jets = 0.;
-	m_pyj2_2Jets = 0.;
-	m_pzj2_2Jets = 0.;
-	m_ej2_2Jets  = 0.;
+    m_2jets4v[1].SetPxPyPzE(0., 0., 0., 0.);
+    m_2jet2_m = 0.;
 
     m_ptjmin2 = 0.;
     m_pjmin2 = 0.;
@@ -156,7 +140,7 @@ void EventObservablesLL::clearChannelValues() {
     m_ptjmax2 = 0.;
     m_pjmax2 = 0.;
 
-    m_m_inv_2Jets = 0.;
+    m_2jet_m_inv = 0.;
 
     m_cosJ1_2Jets = 0.;
 	m_cosJ2_2Jets = 0.;
@@ -168,6 +152,8 @@ void EventObservablesLL::clearChannelValues() {
     m_yMinus2 = 0.;
     m_yPlus2 = 0.;
 
+    m_2jetTags[0].clear();
+    m_2jetTags[1].clear();
     m_bTagValues_2Jets.clear();
     m_bTagValues_2Jets2.clear();
 
@@ -239,15 +225,12 @@ void EventObservablesLL::updateChannelValues(EVENT::LCEvent *pLCEvent) {
         ROOT::Math::PxPyPzEVector p4J1_2Jets = v4(jets_2Jets[0]);
         ROOT::Math::PxPyPzEVector p4J2_2Jets = v4(jets_2Jets[1]);
 
-        m_pxj1_2Jets = p4J1_2Jets.X();
-        m_pyj1_2Jets = p4J1_2Jets.Y();
-        m_pzj1_2Jets = p4J1_2Jets.Z();
-        m_ej1_2Jets  = p4J1_2Jets.E();
+        m_2jets4v[0] = p4J1_2Jets;
+        m_2jets4v[1] = p4J2_2Jets;
 
-        m_pxj2_2Jets = p4J2_2Jets.X();
-        m_pyj2_2Jets = p4J2_2Jets.Y();
-        m_pzj2_2Jets = p4J2_2Jets.Z();
-        m_ej2_2Jets  = p4J2_2Jets.E();
+        m_2jet1_m = p4J1_2Jets.M();
+        m_2jet2_m = p4J2_2Jets.M();
+        m_2jet_m_inv = (p4J1_2Jets + p4J2_2Jets).M();
 
         double pJ1_2Jets = p4J1_2Jets.P();
         double pJ2_2Jets = p4J2_2Jets.P();
@@ -257,8 +240,6 @@ void EventObservablesLL::updateChannelValues(EVENT::LCEvent *pLCEvent) {
 
         m_ptjmax2 = std::max(p4J1_2Jets.Pt(), p4J2_2Jets.Pt());
         m_pjmax2 = std::max(pJ1_2Jets, pJ2_2Jets);
-
-        m_m_inv_2Jets = (p4J1_2Jets + p4J2_2Jets).M();
 
         TVector3 momentum1_2Jets = jets_2Jets[0]->getMomentum();
         TVector3 momentum2_2Jets = jets_2Jets[1]->getMomentum();
@@ -284,23 +265,35 @@ void EventObservablesLL::updateChannelValues(EVENT::LCEvent *pLCEvent) {
 		int _FTAlgoID2 = m_use_tags2 ? jet2PIDh.getAlgorithmID(m_JetTaggingPIDAlgorithm2) : -1;
 
         int BTagID = jet2PIDh.getParameterIndex(_FTAlgoID, m_JetTaggingPIDParameterB);
-        //int CTagID = jet2PIDh.getParameterIndex(_FTAlgoID, m_JetTaggingPIDParameterC);
-
+        int BBarTagID = jet2PIDh.getParameterIndex(_FTAlgoID, m_JetTaggingPIDParameterBbar);
         int BTagID2 = m_use_tags2 ? jet2PIDh.getParameterIndex(_FTAlgoID2, m_JetTaggingPIDParameterB2) : -1;
-        //int CTagID2 = m_use_tags2 ? jet2PIDh.getParameterIndex(_FTAlgoID2, m_JetTaggingPIDParameterC2) : -1;
 
         // extract flavor tag values
         for (int i=0; i<2; ++i) {
             const ParticleIDImpl& FTImpl = dynamic_cast<const ParticleIDImpl&>(jet2PIDh.getParticleID(jets_2Jets[i], _FTAlgoID));
             const FloatVec& FTPara = FTImpl.getParameters();
 
-            m_bTagValues_2Jets[i] = FTPara[BTagID];
+            m_bTagValues_2Jets[i] = FTPara[BTagID] + FTPara[BBarTagID];
+
+            // write all requested parameters
+            for (size_t j = 0; j < m_JetTaggingPIDParameters.size(); j++) {
+                int param_id = jet2PIDh.getParameterIndex(_FTAlgoID, m_JetTaggingPIDParameters[j]);
+                if (param_id + 1 > (int)FTPara.size()) {
+                    std::cerr << "Parameter error: Param " << j << ", value=" << m_JetTaggingPIDParameters[j] << std::endl;
+                    throw EVENT::Exception("No flavor tagging value for parameter");
+                }
+                
+                m_2jetTags[i].push_back(FTPara[param_id]);
+            }
 
             if (m_use_tags2) {
                 const ParticleIDImpl& FTImpl2 = dynamic_cast<const ParticleIDImpl&>(jet2PIDh.getParticleID(jets_2Jets[i], _FTAlgoID2));
                 const FloatVec& FTPara2 = FTImpl2.getParameters();
 
                 m_bTagValues_2Jets2[i] = FTPara2[BTagID2];
+
+                if (std::isnan(m_bTagValues_2Jets[i]) && !std::isnan(m_bTagValues_2Jets2[i]))
+                    m_bTagValues_2Jets[i] = m_bTagValues_2Jets2[i];
             }
         }
 
@@ -311,6 +304,9 @@ void EventObservablesLL::updateChannelValues(EVENT::LCEvent *pLCEvent) {
             m_bmax12_2Jets = std::max(m_bTagValues_2Jets2[0], m_bTagValues_2Jets2[1]);
             m_bmax22_2Jets = std::min(m_bTagValues_2Jets2[0], m_bTagValues_2Jets2[1]);
         }
+
+        // DECAY ANGLES IN Z=qqbar REST FRAME
+        // DONE IN MATRIX ELEMENT CODE SEPARATELY
 
         // END EVALUATE 2 JET COLLECTION
 
@@ -356,16 +352,10 @@ void EventObservablesLL::updateChannelValues(EVENT::LCEvent *pLCEvent) {
             m_errorCodes.push_back(1001);
         }
     
-        m_pxl1 = v4_paired_isolep1.Px();
-        m_pyl1 = v4_paired_isolep1.Py();
-        m_pzl1 = v4_paired_isolep1.Pz();
-        m_el1 = v4_paired_isolep1.E();
+        m_leps4v[0] = v4_paired_isolep1;
         m_typel1 = paired_isolep1->getType();
 
-        m_pxl2 = v4_paired_isolep2.Px();
-        m_pyl2 = v4_paired_isolep2.Py();
-        m_pzl2 = v4_paired_isolep2.Pz();
-        m_el2 = v4_paired_isolep2.E();
+        m_leps4v[1] = v4_paired_isolep2;
         m_typel2 = paired_isolep2->getType();
 
         m_mzll = momentumZv4.M();

--- a/workflows/analysis/configurations.py
+++ b/workflows/analysis/configurations.py
@@ -1,3 +1,15 @@
+# This file contains task parameters to define so-called tags
+# They are a required argument when calling law via
+#     law run <task> --tag=<tag>
+# These allow to re-use many of the task definitions by only
+# varying input files and other task inputs or dynamically
+# injecting task dependencies.
+# Tasks of different tags may also depend on each other. See
+# the 550-4fsl-fast-perf config which depends on 550-4f-fast-
+# perf. For example, the 4f config defines the input for the
+# FastSimSGV to be all available 4f samples, the 4fsl then
+# depends on 4f and only uses the semileptonic samples.
+
 from analysis.framework import AnalysisConfiguration, zhh_configs
 from glob import glob
 from typing import TYPE_CHECKING
@@ -230,8 +242,12 @@ class Config_550_llhh_fast_pfl(AnalysisConfiguration):
     marlin_globals = {  }
     marlin_constants = { 'CMSEnergy': 550 }
 
-class Config_550_llbb_fast_perf(AnalysisConfiguration):
-    tag = '550-llbb-fast-perf'
+class Config_550_4fsl_fast_perf(AnalysisConfiguration):
+    tag = '550-4fsl-fast-perf'
+    
+    custom_statistics = [
+        (1., 'zz_sl0')
+    ]
     
     def raw_index_requires(self, raw_index_task: 'AbstractIndex'):
         # use the output of 550-4f-fast-perf as input
@@ -485,7 +501,7 @@ zhh_configs.add(Config_550_llhh_full())
 # SGV PERF
 # llHH
 zhh_configs.add(Config_550_llhh_fast_perf())
-zhh_configs.add(Config_550_llbb_fast_perf())
+zhh_configs.add(Config_550_4fsl_fast_perf())
 zhh_configs.add(Config_550_2l4q_fast_perf())
 zhh_configs.add(Config_550_bbbb_fast_perf())
 

--- a/workflows/analysis/tasks.py
+++ b/workflows/analysis/tasks.py
@@ -45,7 +45,7 @@ class CreateRecoChunks(AbstractCreateChunks):
 
 class CreateAnalysisChunks(AbstractCreateChunks):
     jobtime:int = cast(int, luigi.IntParameter(description='Maximum runtime of each job. Uses DESY NAF defaults for the vanilla queue.',
-                                               default=3600))
+                                               default=1800))
     
     T0_MARLIN = 4
     
@@ -71,8 +71,65 @@ class AnalysisCombine(ShellTask):
         
         return f"""source $REPO_ROOT/setup.sh
 zhhvenv
-python $REPO_ROOT/zhh/cli/merge_root_files.py "{output_dirn}" "{",".join(ttrees)}]" --dirs="{source_dirn}"
+python $REPO_ROOT/zhh/cli/merge_root_files.py "{output_dirn}" "{",".join(ttrees)}" --dirs="{source_dirn}"
 echo Success""".replace('\n', '  &&  ')
 
+
+class AnalysisGroup(BaseTask):
+    def requires(self):
+        from analysis.configurations import zhh_configs
+        if self.tag == 'LL':
+            return [
+                AnalysisCombine.req(self, tag='550-llhh-fast-perf'),
+                AnalysisCombine.req(self, tag='550-4fsl-fast-perf'),
+                AnalysisCombine.req(self, tag='550-6q-fast-perf'),
+                AnalysisCombine.req(self, tag='550-2l4q-fast-perf')
+            ]
+        else:
+            raise Exception(f'Unknown group tag <{self.tag}>')
+    
+    def complete(self):
+        inputs = self.input()        
+        return all(cast(law.FileSystemTarget, elem).exists() for elem in flatten(inputs))
+    
+    def run(self):
+        print('Reconstruction and analysis with Marlin complete.')
+        
+class AnalysisDelete(BaseTask):
+    def complete(self):
+        from shutil import rmtree
+        from os import environ
+        from law.util import query_choice, colored
+        
+        for task in ['AnalysisCombine', 'AnalysisFinal', 'CreateAnalysisChunks', 'AnalysisRuntime']:
+            directories = []
+            for tag in ['550-llhh-fast-perf', '550-4fsl-fast-perf', '550-6q-fast-perf', '550-2l4q-fast-perf']:
+                directories.append(f'{task}/{tag}')
+        
+            question = f'Task <{task}>: Delete all results? (everything under <{environ["DATA_PATH"]}/{task}>): ? \n\n  ' + '\n  '.join(directories) 
+            
+            confirmation = query_choice(question, ['y', 'n'], default='n')
+            
+            if confirmation == 'y':
+                for item in directories:
+                    path = f'{environ["DATA_PATH"]}/{item}'
+                    if osp.isdir(path):
+                        print(f'Deleting {path}') 
+                        rmtree(path)
+                    else:
+                        print(colored(f'Path {path} skipped: Does not exist', color='green')) 
+                    
+                print(colored(f'Deletion successful!', color='green')) 
+            else:
+                print(colored(f'Skipping', color='yellow')) 
+        
+        self.task_completed = True 
+        
+        return True
+    
+    def run(self):
+        print('Reconstruction and analysis with Marlin complete.')
+        return True
+        
 
 import analysis.configurations

--- a/workflows/analysis/tasks_abstract.py
+++ b/workflows/analysis/tasks_abstract.py
@@ -127,9 +127,10 @@ class AbstractMarlin(ShellTask, HTCondorWorkflow, law.LocalWorkflow):
         
         cmd =  f'source $REPO_ROOT/setup.sh'
         cmd += f' && echo "Starting Marlin at $(date)"'
+        cmd += f' && rm -rf {self.htcondor_output_directory().path}/*-{str(self.branch)}'
         cmd += f' && mkdir -p "{temp}" && cd "{temp}"'
         
-        str_max_record_number = f' --global.MaxRecordNumber={str(n_events_max)}' if n_events_max is not None else ''
+        str_max_record_number = f' --global.MaxRecordNumber={str(n_events_max + 1 if (n_events_max > 0 and n_events_skip is not None and n_events_skip > 0) else n_events_max)}' if n_events_max is not None else ''
         str_skip_n_events = f' --global.SkipNEvents={str(n_events_skip)}' if (n_events_skip is not None and n_events_skip > 0) else ''
         
         cmd += f' && ( {executable} {steering_file} {self.parse_marlin_constants()}{self.parse_marlin_globals()}{str_max_record_number}{str_skip_n_events} --global.LCIOInputFiles="{" ".join(input_files)}" || true )'

--- a/workflows/analysis/tasks_marlin.py
+++ b/workflows/analysis/tasks_marlin.py
@@ -170,6 +170,7 @@ class RecoAbstract(MarlinBaseJob):
     
     check_output_files_exist = ['zhh_reco_FinalStateMeta.json']    
     check_output_root_ttrees = None
+    check_output_lcio_files = ['zhh_reco.slcio']
     
     def workflow_requires(self):
         from .tasks import RawIndex, CreateRecoChunks

--- a/workflows/analysis/utils/task_overviews.py
+++ b/workflows/analysis/utils/task_overviews.py
@@ -89,10 +89,10 @@ def chunk_overview(chunks:np.ndarray,
     is_grouped_m2m = 'src_bname' in chunks.dtype.names
     size_prop_name = 'chunk_size' if not is_m2m else 'sub_branch_size'
     n_branches_tot = len(chunks) if not is_m2m else len(np.unique(chunks['branch']))
-    chunk_mode = 'MANY-TO-ONE' if not is_m2m else ('MANY-TO-MANY (GROUPED)' if is_grouped_m2m else 'MANY-TO-MANY (NON-GROUPED)')
+    chunk_mode = 'ONE-TO-MANY' if not is_m2m else ('MANY-TO-MANY (GROUPED)' if is_grouped_m2m else 'MANY-TO-MANY (NON-GROUPED)')
     
     text = f'''+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-{task_name} Overview: Divided submission into {n_branches_tot} chunks
+{task_name} Overview: Divided submission into {n_branches_tot} chunks with {int(np.sum(chunks[size_prop_name])):,} events
 
     Chunk mode : <{chunk_mode}>
     Chunk list : <{chunk_file_path}>

--- a/zhh/analysis/AnalysisChannel.py
+++ b/zhh/analysis/AnalysisChannel.py
@@ -136,8 +136,13 @@ class AnalysisChannel:
         
         return self._preselection
     
+    def getData(self)->PreselectionSummary:
+        return self.getPreselection()
+    
     def getPreselection(self)->PreselectionSummary:
         """Returns the preselection summary object.
+        
+        Will be deprecated soon in favor of .data()
 
         Returns:
             PreselectionSummary: preselection summary object

--- a/zhh/analysis/FinalStateDefinitions.py
+++ b/zhh/analysis/FinalStateDefinitions.py
@@ -7,9 +7,10 @@ import numpy as np
 FinalStateDefinition = Callable[[AnalysisChannel, FinalStateCounts], np.ndarray]
 
 # define llbb
-define_eebb:FinalStateDefinition = lambda ac, fsc: (fsc.n_e   == 2) & (fsc.n_b == 2)
-define_µµbb:FinalStateDefinition = lambda ac, fsc: (fsc.n_mu  == 2) & (fsc.n_b == 2)
-define_ττbb:FinalStateDefinition = lambda ac, fsc: (fsc.n_tau == 2) & (fsc.n_b == 2)
+define_eebb:FinalStateDefinition = lambda ac, fsc: (fsc.n_e   == 2)         & (fsc.n_b == 2)
+define_µµbb:FinalStateDefinition = lambda ac, fsc: (fsc.n_mu  == 2)         & (fsc.n_b == 2)
+define_ττbb:FinalStateDefinition = lambda ac, fsc: (fsc.n_tau == 2)         & (fsc.n_b == 2)
+define_lvqq:FinalStateDefinition = lambda ac, fsc: (fsc.n_charged_lep == 1) & (fsc.n_q == 2) & (fsc.n_neutral_lep == 1)
 
 # categorize l2q4
 define_lvqqqq:FinalStateDefinition = lambda ac, fsc: (fsc.n_charged_lep == 1) & (fsc.n_neutral_lep == 1) & (fsc.n_q == 4) & (fsc.n_b == 0)
@@ -39,12 +40,13 @@ define_llhh_llbbbb:FinalStateDefinition = lambda ac, fsc: np.logical_or.reduce( 
     (ac.getCategoryMask('eeHHbbbb'), ac.getCategoryMask('µµHHbbbb'), ac.getCategoryMask('ττHHbbbb')))
 define_llqqh:FinalStateDefinition = lambda ac, fsc: np.isin(ac.getPreselection()['process'], [ProcessCategories.e1e1qqh, ProcessCategories.e2e2qqh, ProcessCategories.e3e3qqh])
 
-def categorize_llbb(ac:AnalysisChannel):
+def categorize_4fsl(ac:AnalysisChannel):
     from zhh import EventCategories
     
-    ac.registerEventCategory('eebb', define_eebb, EventCategories.llbb)
-    ac.registerEventCategory('µµbb', define_µµbb, EventCategories.llbb)
-    ac.registerEventCategory('ττbb', define_ττbb, EventCategories.llbb)
+    ac.registerEventCategory('eebb', define_eebb, EventCategories.eebb)
+    ac.registerEventCategory('µµbb', define_µµbb, EventCategories.µµbb)
+    ac.registerEventCategory('ττbb', define_ττbb, EventCategories.𝜏𝜏bb)
+    ac.registerEventCategory('lvqq', define_lvqq, EventCategories.lvqq)
 
 def categorize_2l4q(ac:AnalysisChannel):
     from zhh import EventCategories

--- a/zhh/analysis/__init__.py
+++ b/zhh/analysis/__init__.py
@@ -3,7 +3,8 @@ from .PreselectionAnalysis import get_preselection_meta, get_preselection_summar
     parse_json, calc_preselection_by_event_categories, \
     calc_preselection_by_processes, combined_cross_section, subset_test, weighted_counts_by_categories, \
     fetch_preselection_data, fs_columns, PDG2FSC
-from .RuntimeAnalysis import get_runtime_analysis, evaluate_runtime, get_adjusted_time_per_event
+from .RuntimeAnalysis import get_runtime_analysis, evaluate_runtime, get_adjusted_time_per_event, \
+    sgv_runtime, sgv_runtime_to_samples
 from .Normalization import get_sample_chunk_splits, get_process_normalization, get_chunks_factual, \
     CHUNK_SPLIT_MODES, construct_sample_groups
 from .Cuts import Cut, EqualCut, WindowCut, GreaterThanEqualCut, LessThanEqualCut, CutTypes, apply_cuts
@@ -20,4 +21,4 @@ from .FinalStateDefinitions import define_eebb, define_μμbb, define_ττbb, \
     define_llhh, define_eeHHbbbb, define_µµHHbbbb, define_ττHHbbbb, \
     define_llhh_llbbbb, define_llqqh, \
     FinalStateDefinition, \
-    categorize_llhh, categorize_llbb, categorize_2l4q, categorize_6q
+    categorize_llhh, categorize_4fsl, categorize_2l4q, categorize_6q

--- a/zhh/mem/Physsim/PhyssimWrapper.cpp
+++ b/zhh/mem/Physsim/PhyssimWrapper.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/numpy.h>
 #include "physsim/LCMEZHH.h"
 #include "physsim/LCMEZZH.h"
+#include "physsim/LCMEZZ.h"
 #include "TLorentzVector.h"
 
 namespace py = pybind11;
@@ -17,7 +18,7 @@ py::array_t<double> calc_me_zhh(
     double pol_e,
     double pol_p,
     int zDecayMode,
-    py::array_t<double> kinematics) {
+    py::array_t<double> input_kinematics) {
         
     lcme::LCMEZHH* calcme = new lcme::LCMEZHH("LCMEZHH", "ZHH", 125., pol_e, pol_p);
 
@@ -25,10 +26,10 @@ py::array_t<double> calc_me_zhh(
     calcme->SetPropagator(1);
     //calcme->SetMEType(2);
     
-    py::buffer_info bufIn = kinematics.request();
+    py::buffer_info bufIn = input_kinematics.request();
 
     if (bufIn.ndim != 2)
-        throw std::runtime_error("Number of dimensions must be one");
+        throw std::runtime_error("Number of dimensions must be two");
 
     if (bufIn.shape[1] != 16)
         throw std::runtime_error("Invalid number of kinematic inputs; need array of size (n x 16) in order (px,py,pz,E) for (zdecay1particle, zdecay2particle, higgs1, higgs2) where zdecay1particle is positive, 2 is negative");
@@ -70,7 +71,7 @@ py::array_t<double> calc_me_zzh(
     double pol_p,
     int z1DecayMode,
     int z2DecayMode,
-    py::array_t<double> kinematics) {
+    py::array_t<double> input_kinematics) {
         
     lcme::LCMEZZH* calcme = new lcme::LCMEZZH("LCMEZZH", "ZZH", 125., pol_e, pol_p);
 
@@ -78,10 +79,10 @@ py::array_t<double> calc_me_zzh(
     calcme->SetPropagator(1);
     //calcme->SetMEType(2);
     
-    py::buffer_info bufIn = kinematics.request();
+    py::buffer_info bufIn = input_kinematics.request();
 
     if (bufIn.ndim != 2)
-        throw std::runtime_error("Number of dimensions must be one");
+        throw std::runtime_error("Number of dimensions must be two");
 
     if (bufIn.shape[1] != 20)
         throw std::runtime_error("Invalid number of kinematic inputs; need array of size (n x 20) in order (px,py,pz,E) for (z1decay1particle, z1decay2particle, z2decay1particle, z2decay2particle, higgs1) where zdecay1particle is positive, 2 is negative");
@@ -118,10 +119,97 @@ py::array_t<double> calc_me_zzh(
     return result;
 }
 
+py::array_t<double> calc_me_zz(
+    double pol_e,
+    double pol_p,
+    int z1DecayMode,
+    int z2DecayMode,
+    py::array_t<double> input_kinematics,
+    std::optional<py::array_t<double>> out_rest_frame_data
+) {
+        
+    lcme::LCMEZZ* calcme = new lcme::LCMEZZ("LCMEZZ", "ZZ", pol_e, pol_p, 0);
+
+    calcme->SetZDecayMode(z1DecayMode, z2DecayMode);
+    calcme->SetPropagator(1);
+    //calcme->SetMEType(2);
+    
+    py::buffer_info bufIn = input_kinematics.request();
+
+    if (bufIn.ndim != 2)
+        throw std::runtime_error("Number of dimensions must be two");
+
+    if (bufIn.shape[1] != 16)
+        throw std::runtime_error("Invalid number of kinematic inputs; need array of size (n x 16) in order (px,py,pz,E) for (z1decay1particle, z1decay2particle, z2decay1particle, z2decay2particle) where the first(second) decay particle of each Z is positive(negative)");
+    
+    auto result = py::array_t<double>(std::vector<size_t>{(size_t)bufIn.shape[0]});
+
+    py::buffer_info bufOut = result.request();
+
+    double *ptrIn = static_cast<double *>(bufIn.ptr);
+    double *ptrOut = static_cast<double *>(bufOut.ptr);
+
+    // output cosTheta, phi angles in rest frame of Z1,Z2,ZZ
+    py::buffer_info buf_rf_data;
+    double *rf_angles = nullptr;
+    bool output_rest_frame_data = out_rest_frame_data.has_value();
+    if (output_rest_frame_data) {
+        buf_rf_data = out_rest_frame_data.value().request();
+
+        if (buf_rf_data.ndim != 2 || buf_rf_data.shape[1] != 9)
+            throw std::runtime_error("Invalid number of kinematic inputs; need array of size (n x 9) and will be filled in order (Q^2, CosTheta, Phi) for (Z1, Z2, ZZ system)");
+
+        rf_angles = static_cast<double *>(bufOut.ptr);
+    }    
+
+    TLorentzVector lortz[4];
+
+    unsigned short i;
+
+    for (size_t idx = 0; idx < bufIn.shape[0]; idx++) {
+        for (i = 0; i < 4; i++) {
+            lortz[i].SetPxPyPzE(
+                ptrIn[16*idx + 4*i],
+                ptrIn[16*idx + 4*i + 1],
+                ptrIn[16*idx + 4*i + 2],
+                ptrIn[16*idx + 4*i + 3]);
+            //std::cerr << lortz[i].E() << " ";
+        }
+
+        calcme->SetMomentumFinal(lortz);
+        ptrOut[idx] = calcme->GetMatrixElement2();
+
+        if (output_rest_frame_data) {
+            rf_angles[idx * 9    ] = calcme->GetQ2Z1();
+            rf_angles[idx * 9 + 1] = calcme->GetCosThetaZ1F();
+            rf_angles[idx * 9 + 2] = calcme->GetPhiZ1F();
+
+            rf_angles[idx * 9 + 3] = calcme->GetQ2Z2();
+            rf_angles[idx * 9 + 4] = calcme->GetCosThetaZ2F();
+            rf_angles[idx * 9 + 5] = calcme->GetPhiZ2F();
+
+            rf_angles[idx * 9 + 6] = calcme->GetQ2ZZ();
+            rf_angles[idx * 9 + 7] = calcme->GetCosTheta();
+            rf_angles[idx * 9 + 8] = calcme->GetPhi();
+        }
+        
+        //std::cerr << "-> " << ptrOut[idx] << std::endl;
+    }
+
+    delete calcme;
+
+    return result;
+}
+
 PYBIND11_MODULE(PhyssimWrapper, m) {
     m.doc() = "PhyssimWrapper using pybind11";
 
     m.def("calc_me_zhh", &calc_me_zhh, "Calculate e+e- -> ZHH matrix element");
     m.def("calc_me_zzh", &calc_me_zzh, "Calculate e+e- -> ZZH matrix element");
+    m.def("calc_me_zz", &calc_me_zz, "Calculate e+e- -> ZZ matrix element",
+        py::arg("pol_e"), py::arg("pol_p"),
+        py::arg("z1DecayMode"), py::arg("z2DecayMode"),
+        py::arg("input_kinematics"),
+        py::arg("out_rest_frame_data") = py::none());
     m.def("physsim_get_z_decay_modes", &physsim_get_z_decay_modes, "Get decay modes of Z boson");
 }

--- a/zhh/processes/EventCategories.py
+++ b/zhh/processes/EventCategories.py
@@ -78,6 +78,7 @@ class EVENT_CATEGORY_TRUE:
     
     # SEMILEPTONIC
     lvqq = 65
+    F4_OTHER = 69
 
     # ttbar -> lvbbqq [t->Wb, W->lv/qq, b->bb]
     # so far not accounted: ttbar -> llvvbb (two leptonically decaying W bosons)

--- a/zhh/processes/ProcessCategories.py
+++ b/zhh/processes/ProcessCategories.py
@@ -56,6 +56,14 @@ class PROCESS_CATEGORIES:
     # TEST llbb, eebb
     f4_llbb_sl0 = 3195
     f4_eebb_sl0 = 3196
+    
+    # NEW 4f
+    f4_sw_sl0 = 31940
+    f4_sze_sl0 = 31920
+    f4_sznu_sl0 = 33600
+    f4_ww_sl0 = 31930
+    f4_zz_sl0 = 31910
+    f4_zznu_sl0 = 31970
 
     # fffff
     p5_ae_eeevv = 9101


### PR DESCRIPTION
- Removed TrueJet due to errors, instead using only FinalStateRecorder output (see USE_TRUEJET preprocessor macros)
- Validation of new law workflow
- Updated PhyssimWrapper
- Added AnalysisDelete and AnalysisGroup law tasks for easier management
- Updated flavor training to newest version
- Renamed llbb to more general f4sl (including full new 4f prod)
- Write out all flavor tags per jet (for 4j and 2j) for weaver